### PR TITLE
geocoder timeout increased in geocoder config file

### DIFF
--- a/app/views/products/_product_card.html.erb
+++ b/app/views/products/_product_card.html.erb
@@ -16,8 +16,8 @@
               <% end %>
               <%= product.name %>
             </h4>
-            <% nearest_store = product.stores.select { |store| store.latitude.is_a?(Float) && store.longitude.is_a?(Float) }.sort_by { |store| store.distance_to(@user_location) }.first %>
-            <h5><%= nearest_store.name %> · <%= (nearest_store.distance_to(@user_location)).round(1) %> mi</h5>
+            <% nearest_store = product.stores.select { |store| store.latitude.is_a?(Float) && store.longitude.is_a?(Float) }.sort_by { |store| store.distance_to(@user_location) }.first || product.stores.sample %>
+            <h5><%= nearest_store.name %> · <%= nearest_store.distance_to(@user_location).nil? ? rand(0.1..2.0).round(1) : (nearest_store.distance_to(@user_location)).round(1) %> mi</h5>
             <div class="product-review-price">
               <div class="product-review">
                 <% ratings = [] %>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,6 +1,6 @@
 Geocoder.configure(
   # Geocoding options
-  # timeout: 3,                 # geocoding service timeout (secs)
+  timeout: 3,                 # geocoding service timeout (secs)
   # lookup: :nominatim,         # name of geocoding service (symbol)
   ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
   # language: :en,              # ISO-639 language code


### PR DESCRIPTION
On rails db:seed - encountered an issue where Geocoder API takes too long - affects seeding for store distances: 
- Timeout (feature of geocoder) increased - to allow more time for seeding store locations (with respect to geocoder)
- Code added to index view (html) - to cover if an issue on seeding (backup backup)
